### PR TITLE
Add Release Management documentation (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,17 @@ automatic GitHub Actions SSH deployment, manual fallback deployment, and
 rollback steps are documented in
 [Backend-Deployment.md](documentation/Backend-Deployment.md).
 
+### Release Management
+
+Backend releases are immutable container images published to GHCR on every merge
+to `main`. Production floats on the `latest` tag, while each build is also
+published as an immutable `sha-<short-commit>` tag used for pinning a specific
+release and for rollback (`IMAGE_TAG=sha-<short-commit>`).
+
+The full release flow, tagging conventions, promotion, and rollback procedure
+are documented in
+[Backend-Release-Management.md](documentation/Backend-Release-Management.md).
+
 ### Running the Client
 
 Open the client directory inside Android Studio (Ladybug 2024.2.1+ recommended) or deploy directly via CLI:

--- a/documentation/Backend-Deployment.md
+++ b/documentation/Backend-Deployment.md
@@ -281,6 +281,9 @@ Local-only variables for `compose-dev.yaml`:
 
 ## Rollback
 
+For release tagging conventions and how production releases are promoted, see
+[Backend-Release-Management.md](Backend-Release-Management.md).
+
 To roll back to a previous published image:
 
 1. Identify a known-good `sha-<short-commit>` tag from GHCR or the GitHub Actions

--- a/documentation/Backend-Release-Management.md
+++ b/documentation/Backend-Release-Management.md
@@ -1,0 +1,141 @@
+# Backend Release Management
+
+This document describes how backend releases are produced today: versioned
+container images published to GitHub Container Registry (GHCR) by the
+`SE2-Machi-Koro/Server` repository, the image tagging conventions, and how a
+specific release is promoted to production or rolled back.
+
+It is based on the server repository files:
+
+- `.github/workflows/docker-publish.yml`
+- `compose.yaml`
+
+For the full production stack, environment variables, and the manual fallback
+deployment, see [Backend-Deployment.md](Backend-Deployment.md).
+
+## Release Flow
+
+A release is an immutable container image in GHCR, produced automatically by CI.
+There is no separate manual build step — merging to `main` is the trigger.
+
+```text
+merge PR to main ──▶ CI (docker-publish.yml) ──▶ GHCR image published ──▶ auto deploy to AAU
+                       build-jar                  latest + sha-<short>      (deploy job, SSH)
+                       build-and-push             + main
+```
+
+1. A pull request is merged (or a commit is pushed) to `main`.
+2. The `docker-publish.yml` workflow runs:
+   - `build-jar` builds the Spring Boot jar (`./gradlew bootJar -x test`);
+   - `build-and-push` builds the multi-arch Docker image
+     (`linux/amd64,linux/arm64`) and pushes it to
+     `ghcr.io/se2-machi-koro/server` with the computed tags.
+3. The `deploy` job (runs only on `main`) SSHes into the AAU server and restarts
+   the backend against the new image. See the
+   [Automatic AAU Deployment](Backend-Deployment.md#automatic-aau-deployment)
+   section for details.
+
+The workflow also runs on git tags matching `v*` and on manual
+`workflow_dispatch`. Tag builds publish a versioned image but do **not** run the
+`deploy` job (which is gated on `refs/heads/main`).
+
+## Image Tagging Conventions
+
+Tags are computed by `docker/metadata-action` from this configuration:
+
+```yaml
+tags: |
+  type=ref,event=branch
+  type=ref,event=tag
+  type=sha,prefix=sha-,format=short
+  type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+```
+
+| Tag | Produced when | Purpose |
+| :--- | :--- | :--- |
+| `latest` | Push to `main`. | Floating pointer to the newest `main` build. Default image used by `compose.yaml` (`${IMAGE_TAG:-latest}`). |
+| `sha-<short-commit>` | Every workflow run. | Immutable, traceable handle for one exact commit. Use this to pin a release or roll back. |
+| `main` | Push to `main` (branch ref). | Convenience alias for the current `main` build; equivalent to `latest`. |
+| `v<x.y.z>` | A git tag matching `v*` is pushed. | Human-readable version marker for a milestone/presentation release. |
+
+**Which tag to use:**
+
+- **Production deployment** floats on `latest` by default, so the auto-deploy on
+  every `main` merge always ships the newest build.
+- **Pinning / rollback** must use an immutable `sha-<short-commit>` (or a `v*`)
+  tag. Never pin to `latest`, because it moves with every merge.
+
+## Versioning and Promotion
+
+Promotion to production is implicit: any image that lands on `main` is the
+production release, because the `deploy` job ships it automatically. The "tested"
+gate is therefore the PR's CI and review — a change reaches `main` only after CI
+and SonarCloud pass and the PR is approved.
+
+To run a **specific release** instead of the floating `latest`, pin `IMAGE_TAG`
+in the server-side `.env` (which lives next to `compose.yaml` on the AAU server)
+to an immutable tag:
+
+```env
+# Pin to one exact build instead of the moving `latest` tag
+IMAGE_TAG=sha-abc1234
+```
+
+Then refresh the backend service:
+
+```bash
+docker compose pull backend
+docker compose up -d --no-deps backend
+docker compose ps
+```
+
+To find the `sha-<short-commit>` for a known-good release, open the GitHub
+Actions run for the merge commit, or inspect the package versions in GHCR.
+
+To return to floating production behaviour, set `IMAGE_TAG=latest` (or remove
+the line, since `compose.yaml` defaults to `latest`) and refresh again.
+
+## Rollback
+
+To roll back production to a previously published, known-good image:
+
+1. Identify the target `sha-<short-commit>` tag from the GitHub Actions run of a
+   known-good commit or from the GHCR package versions.
+2. On the AAU server, edit the `.env` next to `compose.yaml`:
+
+```env
+IMAGE_TAG=sha-abc1234
+```
+
+3. Pull and restart only the backend (Postgres is left untouched):
+
+```bash
+docker compose pull backend
+docker compose up -d --no-deps backend
+docker compose ps
+```
+
+4. Verify the public health endpoint reports `UP`:
+
+```bash
+curl -s http://se2-demo.aau.at:53210/actuator/health
+```
+
+Expected response:
+
+```json
+{"status":"UP"}
+```
+
+Because every build is published as an immutable `sha-<short-commit>` image,
+rollback never requires a rebuild — it only repoints `IMAGE_TAG`.
+
+## Verification Checklist
+
+- Merging to `main` publishes `latest`, `main`, and `sha-<short-commit>` images
+  to `ghcr.io/se2-machi-koro/server`.
+- Production floats on `latest`; pinning and rollback use immutable
+  `sha-<short-commit>` tags.
+- A specific release can be selected by setting `IMAGE_TAG` in the server `.env`.
+- Rollback is achieved by repointing `IMAGE_TAG` and refreshing the backend,
+  with no rebuild.


### PR DESCRIPTION
Closes #35.

Adds `documentation/Backend-Release-Management.md` documenting how backend releases are produced today, verified against the server repo's `.github/workflows/docker-publish.yml` and `compose.yaml`.

## Contents
- **Release flow** — merge to `main` → CI (`build-jar` → `build-and-push`) → GHCR image publish → automatic SSH deploy.
- **Image tagging conventions** — `latest`, `sha-<short-commit>`, `main`, and `v<x.y.z>`, with what each is for and which to pin against. The table mirrors the actual `docker/metadata-action` config.
- **Versioning & promotion** — promotion is implicit (anything on `main` ships); how to select a specific release via `IMAGE_TAG`.
- **Rollback** — copy-pasteable procedure via `IMAGE_TAG=sha-<short-commit>`, repointing only the backend with no rebuild.
- **Cross-links** — added from `README.md` (new *Release Management* subsection) and from `Backend-Deployment.md` (Rollback section).

## Notes for reviewers
- This builds on the deployment-doc changes merged in #37; rebased onto current `main`.
- The `deploy` job is gated on `refs/heads/main`, so `v*` tag builds publish a versioned image but do not auto-deploy — documented as such.
- No markdown-lint Gradle build exists in this docs repo locally, so `./gradlew test` was not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)